### PR TITLE
Turning off author name retrieval.

### DIFF
--- a/config/wordpress-to-github.config.json
+++ b/config/wordpress-to-github.config.json
@@ -11,6 +11,7 @@
     "MediaPath": "",
     "GeneralFilePath": "config/general/general.json",
     "ExcludeProperties": ["content", "_links"],
+    "HideAuthorName": true,
     "ApiRequests": [
       {
         "Destination": "redirects/redirects.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "static-content-cannabis",
-  "version": "2.0.1012",
+  "version": "2.0.1045",
   "description": "Static site generator for https://headless.cannabis.ca.gov",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
Turning on HideAuthorName feature, which turns off access to /users api.